### PR TITLE
adjusting build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ https://api.thegraph.com/subgraphs/name/odyssy-automaton/daohaus-rinkeby
 
 https://api.thegraph.com/subgraphs/name/odyssy-automaton/daohaus-xdai
 
+https://api.thegraph.com/subgraphs/name/odyssy-automaton/daohaus-kovan-optimism
+
+https://api.thegraph.com/subgraphs/name/odyssy-automaton/daohaus-optimism
+
 ## Graph explorers
 
 https://thegraph.com/explorer/subgraph/odyssy-automaton/daohaus
@@ -38,6 +42,10 @@ https://thegraph.com/explorer/subgraph/odyssy-automaton/daohaus-kovan
 https://thegraph.com/explorer/subgraph/odyssy-automaton/daohaus-rinkeby
 
 https://thegraph.com/explorer/subgraph/odyssy-automaton/daohaus-xdai
+
+https://thegraph.com/explorer/subgraph/odyssy-automaton/daohaus-kovan-optimism
+
+https://thegraph.com/explorer/subgraph/odyssy-automaton/daohaus-optimism
 
 initial contribution from:
 http://manifesto.designerdao.eth.link/

--- a/manifests/config.js
+++ b/manifests/config.js
@@ -527,4 +527,77 @@ module.exports.config = {
       },
     ],
   },
+  kovanOptimism: {
+    dataSources: [
+      {
+        name: "v21Factory",
+        template: "v21Factory-ds.yaml",
+        address: "0xf89f79A0E5aF89BFa5c4d4FC6F7fD25700bC4905",
+        startBlock: 30606471,
+      },
+      {
+        name: "niftyMinionFactory",
+        template: "niftyMinionFactory-ds.yaml",
+        address: "",  // TODO
+        startBlock: "",  // TODO chanage to number
+      },
+    ],
+    templates: [
+      {
+        name: "v21Template",
+        template: "v21-template.yaml",
+      },
+      {
+        name: "minionTemplate",
+        template: "minion-template.yaml",
+      },
+    ],
+  },
+  optimism: {
+    dataSources: [
+      {
+        name: "v21Factory",
+        template: "v21Factory-ds.yaml",
+        address: "",  // TODO
+        startBlock: "",  // TODO chanage to number
+      },
+      // {
+      //   name: "niftyMinionFactory",
+      //   template: "niftyMinionFactory-ds.yaml",
+      //   address: "0xaD791Ef059A25b6C82e56977C6489974333C5A0C",
+      //   startBlock: 8691275,
+      // },
+      // TODO - superfluid is on optimism, is this a desired feature?
+      // {
+      //   name: "superfluidMinionFactory",
+      //   template: "superfluidMinionFactory-ds.yaml",
+      //   address: "0x4b168c1a1E729F4c8e3ae81d09F02d350fc905ca",
+      //   startBlock: 8541482,
+      // },
+      {
+        name: "safeMinion",
+        template: "safeMinionFactory-ds.yaml",
+        address: "", // TODO
+        startBlock: "",  // TODO chanage to number
+      },
+    ],
+    templates: [
+      {
+        name: "v21Template",
+        template: "v21-template.yaml",
+      },
+      // {
+      //   name: "minionTemplate",
+      //   template: "minion-template.yaml",
+      // },
+      // {
+      //   name: "superfluidMinionTemplate",
+      //   template: "superfluidMinion-template.yaml",
+      // },
+      {
+        name: "safeMinionTemplate",
+        template: "safeMinion-template.yaml",
+      },
+    ],
+  },
 };

--- a/manifests/config.js
+++ b/manifests/config.js
@@ -532,7 +532,7 @@ module.exports.config = {
       {
         name: "v21Factory",
         template: "v21Factory-ds.yaml",
-        address: "0xf89f79A0E5aF89BFa5c4d4FC6F7fD25700bC4905",
+        address: "0x72B8Bf40C8B316753a3E470689DA625759D2b025",
         startBlock: 1710095,
       },
       // {

--- a/manifests/config.js
+++ b/manifests/config.js
@@ -533,13 +533,19 @@ module.exports.config = {
         name: "v21Factory",
         template: "v21Factory-ds.yaml",
         address: "0xf89f79A0E5aF89BFa5c4d4FC6F7fD25700bC4905",
-        startBlock: 30606471,
+        startBlock: 1710095,
       },
+      // {
+      //   name: "niftyMinionFactory",
+      //   template: "niftyMinionFactory-ds.yaml",
+      //   address: "",  // TODO
+      //   startBlock: "",  // TODO chanage to number
+      // },
       {
-        name: "niftyMinionFactory",
-        template: "niftyMinionFactory-ds.yaml",
-        address: "",  // TODO
-        startBlock: "",  // TODO chanage to number
+        name: "safeMinion",
+        template: "safeMinionFactory-ds.yaml",
+        address: "0x19b36b818380ae482256bEd9953266d9720a4212",
+        startBlock: 1721393, // TODO using Transaction Index - is this correct?
       },
     ],
     templates: [
@@ -558,8 +564,8 @@ module.exports.config = {
       {
         name: "v21Factory",
         template: "v21Factory-ds.yaml",
-        address: "",  // TODO
-        startBlock: "",  // TODO chanage to number
+        address: "0x032865ACfc05E769902Fe90Bcc9d511875a74E66",
+        startBlock: 4864699, // TODO using Transaction Index - is this correct?
       },
       // {
       //   name: "niftyMinionFactory",
@@ -577,8 +583,8 @@ module.exports.config = {
       {
         name: "safeMinion",
         template: "safeMinionFactory-ds.yaml",
-        address: "", // TODO
-        startBlock: "",  // TODO chanage to number
+        address: "0xE01F3F0F09E778e1AD83Fbdaa00e86676F317C6e",
+        startBlock: 4865989, // TODO using Transaction Index - is this correct?
       },
     ],
     templates: [

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "prepare:rinkeby": "node manifests/deploy-prep.js rinkeby",
     "prepare:arbitrum": "node manifests/deploy-prep.js arbitrum-one",
     "prepare:celo": "node manifests/deploy-prep.js celo",
+    "prepare:kovan-optimism": "node manifests/deploy-prep.js kovan-optimism",
+    "prepare:optimism": "node manifests/deploy-prep.js optimism",
     "deploy:mainnet": "yarn prepare:mainnet && yarn build:all && graph deploy --node https://api.thegraph.com/deploy/ --ipfs https://api.thegraph.com/ipfs/ odyssy-automaton/daohaus",
     "deploy:xdai": "yarn prepare:xdai && yarn build:all && graph deploy --node https://api.thegraph.com/deploy/ --ipfs https://api.thegraph.com/ipfs/ odyssy-automaton/daohaus-xdai",
     "deploy:matic": "yarn prepare:rinkeby && yarn build:all && yarn prepare:matic && graph deploy --node https://api.thegraph.com/deploy/ --ipfs https://api.thegraph.com/ipfs/ odyssy-automaton/daohaus-matic",
@@ -24,6 +26,8 @@
     "deploy:test": "yarn prepare:xdai && yarn build:all && graph deploy --node https://api.thegraph.com/deploy/ --ipfs https://api.thegraph.com/ipfs/ odyssy-automaton/daohaus-sandbox",
     "deploy:arbitrum": "yarn prepare:rinkeby && yarn build:all && yarn prepare:arbitrum && graph deploy --node https://api.thegraph.com/deploy/ --ipfs https://api.thegraph.com/ipfs/ odyssy-automaton/daohaus-arbitrum",
     "deploy:celo": "yarn prepare:rinkeby && yarn build:all && yarn prepare:celo && graph deploy --node https://api.thegraph.com/deploy/ --ipfs https://api.thegraph.com/ipfs/ odyssy-automaton/daohaus-celo",
+    "deploy:kovan-optimism": "yarn prepare:rinkeby && yarn build:all && yarn prepare:kovan-optimism && graph deploy --node https://api.thegraph.com/deploy/ --ipfs https://api.thegraph.com/ipfs/ odyssy-automaton/daohaus-kovan-optimism",
+    "deploy:optimism": "yarn prepare:rinkeby && yarn build:all && yarn prepare:optimism && graph deploy --node https://api.thegraph.com/deploy/ --ipfs https://api.thegraph.com/ipfs/ odyssy-automaton/daohaus-optimism",
     "deploy:all": "yarn deploy:mainnet && yarn deploy:xdai && yarn deploy:matic && yarn deploy:kovan && yarn deploy:rinkeby && yarn deploy:arbitrum && yarn deploy:celo"
   },
   "dependencies": {


### PR DESCRIPTION
wip update supergraph

a little confused with configuring the `startBlock`on Optimism - making note of [how blocks and time work on Optimism](https://community.optimism.io/docs/developers/build/differences/#block-numbers-and-timestamps) - might be nothing - right now I am using the `Transaction Index` off the deploy tx.

UPDATE - i got an answer to the above question in the Optimism dev support discord - Transaction index is the right attribute to use for subgraphs - heres [the reference](https://discord.com/channels/667044843901681675/887914409207414785/957407954901020713) - might not work for you unless your in their dev discord so heres the back and forth:

![Screen Shot 2022-03-26 at 8 47 26 PM](https://user-images.githubusercontent.com/5998100/160264583-0d26fff1-c293-4ee3-b551-4a302da293e0.png)

[Deploy Transaction for `Mainnet Optimism` `MolochSummoner`](https://optimistic.etherscan.io/tx/0x5748d39d85099cc2dcff090eaf1984a44a7791c08724b17f2c7f42d40e8d35c3)

[Deploy Transaction for `Kovan Optimism` `MolochSummoner`](https://kovan-optimistic.etherscan.io/tx/0x7a5e140331ead26defbfb8390c1734b272a245c4270818324bb0e34395af749f)