### PR TITLE
add support for Nomad Safe module

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -185,6 +185,7 @@ type Minion @entity {
   crossChainMinion: Boolean!
   foreignChainId: String
   foreignSafeAddress: Bytes
+  bridgeModule: String
   version: String
   minQuorum: BigInt
   streams: [MinionStream!] @derivedFrom(field: "minion")

--- a/src/safe-minion-factory-mapping.ts
+++ b/src/safe-minion-factory-mapping.ts
@@ -19,9 +19,11 @@ function setupMinion(event: SummonMinion, version: string): void {
   log.info("**** summoned safeminion: {}, moloch: {}", [minionId, molochId]);
 
   let details = event.params.details;
-  if (details.startsWith("0xab270234")) {
+  if (details.startsWith("0xab270234") || details.startsWith("0xfc3b5b76")) {
     // bytes4(keccak256(abi.encodePacked('AMBMinionSafe'))) === 0xab270234
+    // bytes4(keccak256(abi.encodePacked("NomadMinionSafe"))) === 0xfc3b5b76
     let fields = details.split("/");
+    minion.bridgeModule = fields[0] == "0xab270234" ? "AMBModule" : "NomadModule";
     minion.details = fields[1];
     minion.crossChainMinion = true;
     minion.foreignChainId = fields[2];


### PR DESCRIPTION
- Adds a new field `bridgeModule` to support both AMB and Nomad Safe modules for cross-chain communication
- Updates Safe Minion name parser to support the new Nomad boost